### PR TITLE
Json loading changes on the client for compatibility with Neocities' CSP

### DIFF
--- a/comics.js
+++ b/comics.js
@@ -14,7 +14,7 @@ function loadWebringJSON_comics(url) {
 }
 
 function webringDataReady_comics(json) {
-  DATA_comics = json;
+  DATA_comics = JSON.parse(json);
   customElements.get('smallweb-subway-comics') || (
     customElements.define('smallweb-subway-comics', Webring_comics));
 }

--- a/comics.js
+++ b/comics.js
@@ -9,9 +9,8 @@ let DATA_comics;
 loadWebringJSON_comics(WEBRING_DATA_URL_comics);
 
 function loadWebringJSON_comics(url) {
-  fetch(url)
-    .then(response => response.json())
-    .then((json) => {webringDataReady_comics(json)});
+  document.write('<script src="'+url+'"></script>');
+  document.close();
 }
 
 function webringDataReady_comics(json) {

--- a/comics.json
+++ b/comics.json
@@ -1,4 +1,4 @@
-[
+webringDataReady_comics(`[
   {
     "name" : "Smallweb Subway",
     "url" : "gusbus.space/smallweb-subway/",
@@ -44,5 +44,5 @@
     "url" : "www.yukiclarke.com/home/",
     "owner" : "Yuki Clarke"
   }
-]
+]`);
 

--- a/creativesclub.js
+++ b/creativesclub.js
@@ -9,9 +9,8 @@ let DATA_creativesclub;
 loadWebringJSON_creativesclub(WEBRING_DATA_URL_creativesclub);
 
 function loadWebringJSON_creativesclub(url) {
-  fetch(url)
-    .then(response => response.json())
-    .then((json) => {webringDataReady_creativesclub(json)});
+  document.write('<script src="'+url+'"></script>');
+  document.close();
 }
 
 function webringDataReady_creativesclub(json) {

--- a/creativesclub.js
+++ b/creativesclub.js
@@ -14,7 +14,7 @@ function loadWebringJSON_creativesclub(url) {
 }
 
 function webringDataReady_creativesclub(json) {
-  DATA_creativesclub = json;
+  DATA_creativesclub = JSON.parse(json);
   customElements.get('smallweb-subway-creativesclub') || (
     customElements.define('smallweb-subway-creativesclub', Webring_creativesclub));
 }

--- a/creativesclub.js
+++ b/creativesclub.js
@@ -36,7 +36,7 @@ function goToPrev_creativesclub() {
 function goToNext_creativesclub() {
   // The leading '//' treats the link as an external site, even without "https:"
   if (typeof forceNewTab_creativesclub !== 'undefined' && forceNewTab_creativesclub) {
-    window.open('//' + DATA_creativesclub[prevSiteIndex_creativesclub].url)
+    window.open('//' + DATA_creativesclub[nextSiteIndex_creativesclub].url)
   } else {
     window.top.location.href = '//' + DATA_creativesclub[nextSiteIndex_creativesclub].url
   }

--- a/creativesclub.json
+++ b/creativesclub.json
@@ -1,4 +1,4 @@
-[
+webringDataReady_creativesclub(`[
   {
     "name" : "Smallweb Subway",
     "url" : "gusbus.space/smallweb-subway/",
@@ -39,5 +39,5 @@
     "url" : "michi.foo/0",
     "owner" : "Sara"
   }
-]
+]`);
 

--- a/doodlecrew.js
+++ b/doodlecrew.js
@@ -25,7 +25,7 @@ function loadWebringJSON_doodlecrew(url) {
 }
 
 function webringDataReady_doodlecrew(json) {
-  DATA_doodlecrew = json;
+  DATA_doodlecrew = JSON.parse(json);
   customElements.get('smallweb-subway-doodlecrew') || customElements.define('smallweb-subway-doodlecrew', Webring_doodlecrew);
 }
 

--- a/doodlecrew.js
+++ b/doodlecrew.js
@@ -20,9 +20,8 @@ loadWebringJSON_doodlecrew(WEBRING_DATA_URL_doodlecrew);
   // }
 
 function loadWebringJSON_doodlecrew(url) {
-  fetch(url)
-    .then(response => response.json())
-    .then((json) => {webringDataReady_doodlecrew(json)});
+  document.write('<script src="'+url+'"></script>');
+  document.close();
 }
 
 function webringDataReady_doodlecrew(json) {

--- a/doodlecrew.json
+++ b/doodlecrew.json
@@ -1,4 +1,4 @@
-[
+webringDataReady_doodlecrew(`[
   {
     "name" : "Smallweb Subway",
     "url" : "gusbus.space/smallweb-subway/",
@@ -34,5 +34,5 @@
     "url" : "gusbus.space/doodlebot/",
     "owner" : "Gus Becker"
   }
-]
+]`);
 

--- a/poetry.js
+++ b/poetry.js
@@ -14,7 +14,7 @@ function loadWebringJSON_poetry(url) {
 }
 
 function webringDataReady_poetry(json) {
-  DATA_poetry = json;
+  DATA_poetry = JSON.parse(json);
   customElements.get('smallweb-subway-poetry') || (
     customElements.define('smallweb-subway-poetry', Webring_poetry));
 }

--- a/poetry.js
+++ b/poetry.js
@@ -9,9 +9,8 @@ let DATA_poetry;
 loadWebringJSON_poetry(WEBRING_DATA_URL_poetry);
 
 function loadWebringJSON_poetry(url) {
-  fetch(url)
-    .then(response => response.json())
-    .then((json) => {webringDataReady_poetry(json)});
+  document.write('<script src="'+url+'"></script>');
+  document.close();
 }
 
 function webringDataReady_poetry(json) {

--- a/poetry.json
+++ b/poetry.json
@@ -1,4 +1,4 @@
-[
+webringDataReady_poetry(`[
   {
     "name" : "Smallweb Subway",
     "url" : "gusbus.space/smallweb-subway/",
@@ -19,5 +19,5 @@
     "url" : "flowerinbinary.neocities.org/home/poetry",
     "owner" : "tim flower"
   }
-]
+]`);
 

--- a/scifi.js
+++ b/scifi.js
@@ -36,7 +36,7 @@ function goToPrev_scifi() {
 function goToNext_scifi() {
   // The leading '//' treats the link as an external site, even without "https:"
   if (typeof forceNewTab_scifi !== 'undefined' && forceNewTab_scifi) {
-    window.open('//' + DATA_scifi[prevSiteIndex_scifi].url)
+    window.open('//' + DATA_scifi[nextSiteIndex_scifi].url)
   } else {
     location.href = '//' + DATA_scifi[nextSiteIndex_scifi].url
   }

--- a/scifi.js
+++ b/scifi.js
@@ -9,9 +9,8 @@ let DATA_scifi;
 loadWebringJSON_scifi(WEBRING_DATA_URL_scifi);
 
 function loadWebringJSON_scifi(url) {
-  fetch(url)
-    .then(response => response.json())
-    .then((json) => {webringDataReady_scifi(json)});
+  document.write('<script src="'+url+'"></script>');
+  document.close();
 }
 
 function webringDataReady_scifi(json) {

--- a/scifi.js
+++ b/scifi.js
@@ -14,7 +14,7 @@ function loadWebringJSON_scifi(url) {
 }
 
 function webringDataReady_scifi(json) {
-  DATA_scifi = json;
+  DATA_scifi = JSON.parse(json);
   customElements.get('smallweb-subway-scifi') || (
     customElements.define('smallweb-subway-scifi', Webring_scifi));
 }

--- a/scifi.json
+++ b/scifi.json
@@ -25,6 +25,11 @@
     "owner" : "Dion Ra"
   },
   {
+    "name" : "Codex Archonic",
+    "url" : "lerariemann.neocities.org/",
+    "owner" : "Lera Riemann"
+  },
+  {
     "name" : "yukiclarke.com",
     "url" : "www.yukiclarke.com/home/",
     "owner" : "Yuki Clarke"

--- a/scifi.json
+++ b/scifi.json
@@ -1,4 +1,4 @@
-[
+webringDataReady_scifi(`[
   {
     "name" : "Smallweb Subway",
     "url" : "gusbus.space/smallweb-subway/",
@@ -34,5 +34,5 @@
     "url" : "www.yukiclarke.com/home/",
     "owner" : "Yuki Clarke"
   }
-]
+]`);
 

--- a/zines.js
+++ b/zines.js
@@ -9,9 +9,8 @@ let DATA_zines;
 loadWebringJSON_zines(WEBRING_DATA_URL_zines);
 
 function loadWebringJSON_zines(url) {
-  fetch(url)
-    .then(response => response.json())
-    .then((json) => {webringDataReady_zines(json)});
+  document.write('<script src="'+url+'"></script>');
+  document.close();
 }
 
 function webringDataReady_zines(json) {

--- a/zines.js
+++ b/zines.js
@@ -14,7 +14,7 @@ function loadWebringJSON_zines(url) {
 }
 
 function webringDataReady_zines(json) {
-  DATA_zines = json;
+  DATA_zines = JSON.parse(json);
   customElements.get('smallweb-subway-zines') || (
     customElements.define('smallweb-subway-zines', Webring_zines));
 }

--- a/zines.json
+++ b/zines.json
@@ -1,4 +1,4 @@
-[
+webringDataReady_zines(`[
   {
     "name" : "Smallweb Subway",
     "url" : "gusbus.space/smallweb-subway/",
@@ -29,5 +29,5 @@
     "url" : "ethersent.neocities.org/",
     "owner" : "Emil Aisling"
   }
-]
+]`);
 


### PR DESCRIPTION
Hi!

When trying to get ready for requestion to add my website to the scifi webring, i noticed a problem, in which the widget of the subway wasn't working on my website as-is. The problem, as I found out, was caused by how you are requesting the JSON files with webring layouts: the scifi.js loads scifi.json via fetch(url), which is disallowed by the Content Security Policy for new accounts on Neocities (see [here](https://github.com/neocities/neocities/issues/484)).

As Neocities is one of the popular hostings for personal websites, i figured out that brewing a fix would be beneficial for everyone. The way I did it was by essentially wrapping the contents of JSON files in JS code, which makes them loadable with a <script> tag. [Here](https://lerariemann.neocities.org/) you can see this version of the code being locally executed (i made some stylistic changes to the widget in there, otherwise the code is the same as the one in this PR).