### PR TITLE
Update comics.js

### DIFF
--- a/comics.js
+++ b/comics.js
@@ -94,7 +94,7 @@ document.addEventListener('DOMContentLoaded', function() {
   setData_comics();
 }, false);
 
-class webring_comics extends HTMLElement {
+class Webring_comics extends HTMLElement {
   constructor() {
     super()
     this.attachShadow({ mode: "open" })


### PR DESCRIPTION
Comics line widget wasn't loading due to an uncaught ReferenceError: Webring_comics is not defined.

On line 97 Webring_comics was in lower case as webring_comics. Updated to capital W. I think this is the error.